### PR TITLE
Add function name to lambda for output template. This is required whe…

### DIFF
--- a/chalice/package.py
+++ b/chalice/package.py
@@ -187,6 +187,7 @@ class SAMTemplateGenerator(TemplateGenerator):
         lambdafunction_definition = {
             'Type': 'AWS::Serverless::Function',
             'Properties': {
+                'FunctionName': resource.function_name,
                 'Runtime': resource.runtime,
                 'Handler': resource.handler,
                 'CodeUri': resource.deployment_package.filename,

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -684,6 +684,7 @@ class TestSAMTemplate(TemplateTestBase):
         assert cfn_resource == {
             'Type': 'AWS::Serverless::Function',
             'Properties': {
+                'FunctionName': 'app-dev-foo',
                 'CodeUri': 'foo.zip',
                 'Handler': 'app.app',
                 'MemorySize': 128,
@@ -763,6 +764,7 @@ class TestSAMTemplate(TemplateTestBase):
         assert cfn_resource == {
             'Type': 'AWS::Serverless::Function',
             'Properties': {
+                'FunctionName': 'app-dev-foo',
                 'CodeUri': 'foo.zip',
                 'Handler': 'app.app',
                 'MemorySize': 128,


### PR DESCRIPTION
…n you want to have a static name for your lambda which may be called by other client libraries

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
